### PR TITLE
Fixed rolling forecasts and added tests

### DIFF
--- a/pkg/R/cvts.R
+++ b/pkg/R/cvts.R
@@ -143,7 +143,7 @@ cvts <- function(x, FUN = NULL, FCFUN = NULL,
   # Combined code for rolling/nonrolling CV
 
   results <- matrix(NA,
-                    nrow = ifelse(rolling, length(x) - windowSize - maxHorizon, as.integer((length(x) - windowSize) / maxHorizon)),
+                    nrow = ifelse(rolling, length(x) - windowSize - maxHorizon + 1, as.integer((length(x) - windowSize) / maxHorizon)),
                     ncol = maxHorizon)
 
   forecasts <- fits <- vector("list", nrow(results))
@@ -161,10 +161,11 @@ cvts <- function(x, FUN = NULL, FCFUN = NULL,
     }
     # Sample the correct slice for rolling
     if(rolling){
-      etsp <- stsp + (i + windowSize - 2) / frequency(x)
+      etsp <- stsp + (windowSize - 1)/frequency(x)
       y <- window(x, start = stsp, end = etsp)
-      fstsp <- stsp + (i + windowSize - 1) / frequency(x)
+      fstsp <- stsp + windowSize / frequency(x)
       fetsp <- fstsp + (maxHorizon - 1) / frequency(x)
+      stsp <- stsp + 1 / frequency(x)
     }
     # Sample the correct slice for nonrolling
     else{

--- a/pkg/tests/testthat/test-cvts.R
+++ b/pkg/tests/testthat/test-cvts.R
@@ -16,4 +16,29 @@ if(require(forecast) &  require(testthat)){
      cv <- cvts(AirPassengers)
      expect_error(accuracy(cv), NA)
   })
+  test_that("Rolling forecasts work", {
+     naive_forecast <- function(train) {
+        result <- list()
+        result$series <- train
+        result$forecast <- train[length(train)]
+        class(result) <- "naive_model"
+        return(result)
+     }
+     
+     forecast.naive_model <- function(model, h = 12) {
+        result <- list()
+        result$model <- model
+        result$mean <- rep(model$forecast, h)
+        class(result) <- "forecast"
+        return(result)
+     }
+     
+     cv <- cvts(AirPassengers, FUN = naive_forecast, FCFUN = forecast, rolling = TRUE, windowSize = 1,
+                maxHorizon = 1)
+     
+     forecasts <- vapply(cv$forecasts, function(x) x[[2]], numeric(1))
+     train_series <- vapply(cv$forecasts, function(x) x[[1]]$series, numeric(1))
+     expect_equal(AirPassengers[1:(length(AirPassengers) - 1)], train_series)
+     expect_equal(AirPassengers[1:(length(AirPassengers) - 1)], forecasts)
+  })
 }


### PR DESCRIPTION
Rolling forecasts were not working in the original version of the package ie. a sliding window was not being used to train. This PR fixes that. Also added tests