### PR TITLE
Extract rolling forecasts and allow argument pass through

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -16,7 +16,8 @@ Depends:
     ggplot2 (>= 2.2.0),
     forecast (>= 7.3)
 Imports:
-    reshape2 (>= 1.4.2)
+    reshape2 (>= 1.4.2),
+    purrr (>= 0.2.1)
 Suggests:
     knitr,
     rmarkdown,

--- a/pkg/R/cvts.R
+++ b/pkg/R/cvts.R
@@ -19,6 +19,7 @@
 #' @param saveModels should the individual models be saved? Set this to \code{FALSE} on long time series to save memory.
 #' @param saveForecasts should the individual forecast from each model be saved? Set this to \code{FALSE} on long time series to save memory.
 #' @param verbose should the current progress be printed to the console?
+#' @param ... Other arguments to be passed to the model function FUN
 #'
 #' @details Cross validation of time series data is more complicated than regular k-folds or leave-one-out cross validation of datasets
 #' without serial correlation since observations \eqn{x_t}{x[t]} and \eqn{x_{t+n}}{x[t+n]} are not independent. The \code{cvts()} function overcomes
@@ -101,7 +102,7 @@ cvts <- function(x, FUN = NULL, FCFUN = NULL,
                  horizonAverage = FALSE,
                  saveModels = ifelse(length(x) > 500, FALSE, TRUE),
                  saveForecasts = ifelse(length(x) > 500, FALSE, TRUE),
-                 verbose = TRUE){
+                 verbose = TRUE, ...){
   # Default model function
   # This can be useful for methods that estimate the model and forecasts in one step
   # e.g. GMDH() from the "GMDH" package or thetaf()/meanf()/rwf() from "forecast". In this case,
@@ -177,7 +178,7 @@ cvts <- function(x, FUN = NULL, FCFUN = NULL,
     ynext <- window(x, start = fstsp, end = fetsp)
 
     # Perfom the simulation
-    mod <- do.call(FUN, list(y))
+    mod <- do.call(FUN, list(y, ...))
     fc <- do.call(FCFUN, list(mod, h = maxHorizon))
     if(saveModels){
       fits[[i]] <- mod

--- a/pkg/R/cvts.R
+++ b/pkg/R/cvts.R
@@ -204,5 +204,30 @@ cvts <- function(x, FUN = NULL, FCFUN = NULL,
   return(result)
 }
 
-
+#' Extract cross validated rolling forecasts
+#' 
+#' Obtain cross validated forecasts when rolling cross validation is used. The object is not
+#' inspected to see if it was fit using a rolling origin
+#' 
+#' @importFrom purrr map
+#' @importFrom purrr reduce
+#' @export 
+#' @param cvts An object of class cvts
+#' 
+#' @return Forecasts computed via a rolling origin
+#' 
+#' @details Combine the cross validated forecasts fit with a rolling origin. This may be useful
+#' to visualize and investigate the cross validated performance of the model
+#' 
+#' @examples 
+#' \dontrun{
+#' cv <- cvts(AirPassengers, FUN = "ets", FCFUN = "forecast", 
+#'         rolling = TRUE, windowSize = 12, horizon = 2)
+#' 
+#' extract_rolling_forecasts(cv)
+#' }
+extract_rolling_forecasts <- function(cvts) {
+   map(cvts$forecasts, ~ .x$mean) %>%
+      reduce(combine_ts)
+}
 

--- a/pkg/R/helper.R
+++ b/pkg/R/helper.R
@@ -1,0 +1,27 @@
+#' Combine multiple sequential time series
+#'
+#' Combine multiple ts objects into a single ts object. It is assumed that the ts objects provided
+#' are sequential. In other words, it is assumed that a valid time series object can actually 
+#' be constructed from the provided objects. The start time and frequency of the combined object 
+#' will correspond to the start time and frequency of the first provided object
+#' 
+#' @export
+#' @param ... ts objects to combine
+#' 
+#' @return A combined ts object generated from the individual ts objects
+#' 
+#' @details Combine sequential time series objects into a single time series object. This might
+#' be useful, for example, when you want to combine the training and validation time series objects
+#' for plotting. The function assumes that the provided objects refer to a sequential time.
+#' For example, a valid argument set would have two time series with periods from Jan-Dec 2015
+#' and Jan-Dec 2016. An invalid set would be two time series with periods from Jan-Dec 2015
+#' and Feb-Dec 2016. No sanity checks are performed, so it is the caller's responsiblity to ensure
+#' that the time series are sequential
+#' 
+#' @examples 
+#' combine_ts(window(AirPassengers, end = c(1951, 12)), window(AirPassengers, start = c(1952, 1)))
+combine_ts <- function(...) {
+   ts.union(..., dframe = TRUE) %>%
+      apply(1, function(x) x[min(which(!is.na(x)))]) %>%
+      ts(start = start(...), frequency = frequency(...))
+}

--- a/pkg/tests/testthat/test-cvts.R
+++ b/pkg/tests/testthat/test-cvts.R
@@ -40,5 +40,19 @@ if(require(forecast) &  require(testthat)){
      train_series <- vapply(cv$forecasts, function(x) x[[1]]$series, numeric(1))
      expect_equal(AirPassengers[1:(length(AirPassengers) - 1)], train_series)
      expect_equal(AirPassengers[1:(length(AirPassengers) - 1)], forecasts)
-  })
+   })
+  
+   test_that("Additional parameters can be passed to fitting functions", {
+      cv <- cvts(AirPassengers, FUN = ets, FCFUN = forecast, rolling = FALSE, windowSize = 12,
+                 maxHorizon = 12, model = "MAM")
+      
+      fc_last <- cv$forecasts[[11]]
+      ets_fit <- ets(window(AirPassengers, end = c(1959, 12)), model = "MAM")
+      
+      ## The call objects alone are different seemingly because of the do.call used in cvts
+      ets_without_call <- forecast(ets_fit, 12) %>% {.[setdiff(names(.), c("model", "call"))]}
+      fc_last_without_call <- cv$forecasts[[11]][setdiff(names(cv$forecasts[[11]]), c("model", "call"))]
+      
+      expect_identical(ets_without_call, fc_last_without_call)
+   })
 }


### PR DESCRIPTION
Currently additional parameters cannot be passed to the fitting function without creating custom models. eg. If you want to fit an ets model of type "MMM", you would have to create a custom function. This PR will pass through any additional params to the fitting function.