### PR TITLE
Fixed wrong URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The latest development version can be installed using the [devtools](https://cra
 
 
 ```r
-devtools::install_gitlab("dashaub/forecastHybrid/pkg")
+devtools::install_gitlab("ellisp/forecastHybrid/pkg")
 ```
 Version updates to CRAN will be published frequently after new features are implemented, so the development version is not recommended unless you plan to modify the code or a particular bugfix is needed.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The latest development version can be installed using the [devtools](https://cra
 
 
 ```r
-devtools::install_gitlab("ellisp/forecastHybrid/pkg")
+devtools::install_github("ellisp/forecastHybrid/pkg")
 ```
 Version updates to CRAN will be published frequently after new features are implemented, so the development version is not recommended unless you plan to modify the code or a particular bugfix is needed.
 


### PR DESCRIPTION
devtools::install_gitlab("dashaub/forecastHybrid/pkg") fails because the repository does not exist. The url must be changed to 'ellisp/forecastHybrid/pkg'.