### PR TITLE
Update accuracy formals for upcoming forecast package release

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Convenient functions for ensemble forecasts in R combining
     and forecasting functions is also supported to evaluate model accuracy.
 Depends:
     R (>= 3.1.1),
-    forecast (>= 8.1),
+    forecast (>= 8.12),
     thief
 Imports:
     doParallel (>= 1.0.10),

--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -33,7 +33,7 @@ License: GPL-3
 URL: https://gitlab.com/dashaub/forecastHybrid, https://github.com/ellisp/forecastHybrid
 BugReports: https://github.com/ellisp/forecastHybrid/issues
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 ByteCompile: true
 NeedsCompilation: no
 Encoding: UTF-8

--- a/pkg/R/generics.R
+++ b/pkg/R/generics.R
@@ -69,9 +69,10 @@ residuals.hybridModel <- function(object,
 #'
 #' Return the in-sample accuracy measures for the component models of the hybridModel
 #'
-#' @param f the input hybridModel.
+#' @param object the input hybridModel.
 #' @param individual if \code{TRUE}, return the accuracy of the component models instead
 #' of the accuracy for the whole ensemble model.
+#' @param f Deprecated. Please use `object` instead.
 #' @param ... other arguments (ignored).
 #' @seealso \code{\link[forecast]{accuracy}}
 #' @return The accuracy of the ensemble or individual component models.
@@ -79,18 +80,23 @@ residuals.hybridModel <- function(object,
 #'
 #' @author David Shaub
 #'
-accuracy.hybridModel <- function(f,
+accuracy.hybridModel <- function(object,
                                  individual = FALSE,
-                                 ...){
+                                 ...,
+                                 f = NULL){
+  if(!is.null(f)){
+    warning("Using `f` as the argument for `accuracy()` is deprecated. Please use `object` instead.")
+    object <- f
+  }
   #chkDots(...)
   if(individual){
     results <- list()
-    for(model in f$models){
-      results[[model]] <- forecast::accuracy(f[[model]])
+    for(model in object$models){
+      results[[model]] <- forecast::accuracy(object[[model]])
     }
     return(results)
   }
-  return(forecast::accuracy(f$fitted, getResponse(f)))
+  return(forecast::accuracy(object$fitted, getResponse(object)))
 }
 
 #' Accuracy measures for cross-validated time series
@@ -98,7 +104,8 @@ accuracy.hybridModel <- function(f,
 #' Returns range of summary measures of the cross-validated forecast accuracy
 #' for \code{cvts} objects.
 #'
-#' @param f a \code{cvts} objected created by \code{\link{cvts}}.
+#' @param object a \code{cvts} objected created by \code{\link{cvts}}.
+#' @param f Deprecated. Please use `object` instead.
 #' @param ... other arguments (ignored).
 #'
 #' @details
@@ -108,11 +115,15 @@ accuracy.hybridModel <- function(f,
 #' @export
 #' @author David Shaub
 #' 
-accuracy.cvts <- function(f, ...){
-  ME <- colMeans(f$residuals)
-  RMSE <- apply(f$residuals, MARGIN = 2,
+accuracy.cvts <- function(object, ..., f = NULL){
+  if(!is.null(f)){
+    warning("Using `f` as the argument for `accuracy()` is deprecated. Please use `object` instead.")
+    object <- f
+  }
+  ME <- colMeans(object$residuals)
+  RMSE <- apply(object$residuals, MARGIN = 2,
                 FUN = function(x){sqrt(sum(x ^ 2)/ length(x))})
-  MAE <- colMeans(abs(f$residuals))
+  MAE <- colMeans(abs(object$residuals))
   results <- data.frame(ME, RMSE, MAE)
   rownames(results) <- paste("Forecast Horizon ", rownames(results))
   # MASE TODO

--- a/pkg/man/accuracy.cvts.Rd
+++ b/pkg/man/accuracy.cvts.Rd
@@ -4,12 +4,14 @@
 \alias{accuracy.cvts}
 \title{Accuracy measures for cross-validated time series}
 \usage{
-\method{accuracy}{cvts}(f, ...)
+\method{accuracy}{cvts}(object, ..., f = NULL)
 }
 \arguments{
-\item{f}{a \code{cvts} objected created by \code{\link{cvts}}.}
+\item{object}{a \code{cvts} objected created by \code{\link{cvts}}.}
 
 \item{...}{other arguments (ignored).}
+
+\item{f}{Deprecated. Please use `object` instead.}
 }
 \description{
 Returns range of summary measures of the cross-validated forecast accuracy

--- a/pkg/man/accuracy.hybridModel.Rd
+++ b/pkg/man/accuracy.hybridModel.Rd
@@ -4,15 +4,17 @@
 \alias{accuracy.hybridModel}
 \title{Accuracy measures for hybridModel objects}
 \usage{
-\method{accuracy}{hybridModel}(f, individual = FALSE, ...)
+\method{accuracy}{hybridModel}(object, individual = FALSE, ..., f = NULL)
 }
 \arguments{
-\item{f}{the input hybridModel.}
+\item{object}{the input hybridModel.}
 
 \item{individual}{if \code{TRUE}, return the accuracy of the component models instead
 of the accuracy for the whole ensemble model.}
 
 \item{...}{other arguments (ignored).}
+
+\item{f}{Deprecated. Please use `object` instead.}
 }
 \value{
 The accuracy of the ensemble or individual component models.

--- a/pkg/man/cvts.Rd
+++ b/pkg/man/cvts.Rd
@@ -4,11 +4,22 @@
 \alias{cvts}
 \title{Cross validation for time series}
 \usage{
-cvts(x, FUN = NULL, FCFUN = NULL, rolling = FALSE, windowSize = 84,
-  maxHorizon = 5, horizonAverage = FALSE, xreg = NULL,
+cvts(
+  x,
+  FUN = NULL,
+  FCFUN = NULL,
+  rolling = FALSE,
+  windowSize = 84,
+  maxHorizon = 5,
+  horizonAverage = FALSE,
+  xreg = NULL,
   saveModels = ifelse(length(x) > 500, FALSE, TRUE),
-  saveForecasts = ifelse(length(x) > 500, FALSE, TRUE), verbose = TRUE,
-  num.cores = 2L, extraPackages = NULL, ...)
+  saveForecasts = ifelse(length(x) > 500, FALSE, TRUE),
+  verbose = TRUE,
+  num.cores = 2L,
+  extraPackages = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{the input time series.}

--- a/pkg/man/forecast.hybridModel.Rd
+++ b/pkg/man/forecast.hybridModel.Rd
@@ -4,9 +4,16 @@
 \alias{forecast.hybridModel}
 \title{Hybrid forecast}
 \usage{
-\method{forecast}{hybridModel}(object, h = ifelse(object$frequency > 1, 2
-  * object$frequency, 10), xreg = NULL, level = c(80, 95), PI = TRUE,
-  fan = FALSE, PI.combination = c("extreme", "mean"), ...)
+\method{forecast}{hybridModel}(
+  object,
+  h = ifelse(object$frequency > 1, 2 * object$frequency, 10),
+  xreg = NULL,
+  level = c(80, 95),
+  PI = TRUE,
+  fan = FALSE,
+  PI.combination = c("extreme", "mean"),
+  ...
+)
 }
 \arguments{
 \item{object}{a hybrid time series model fit with \link{hybridModel}.}

--- a/pkg/man/forecast.thetam.Rd
+++ b/pkg/man/forecast.thetam.Rd
@@ -4,8 +4,13 @@
 \alias{forecast.thetam}
 \title{Forecast using a Theta model}
 \usage{
-\method{forecast}{thetam}(object, h = ifelse(object$m > 1, 2 * object$m,
-  10), level = c(80, 95), fan = FALSE, ...)
+\method{forecast}{thetam}(
+  object,
+  h = ifelse(object$m > 1, 2 * object$m, 10),
+  level = c(80, 95),
+  fan = FALSE,
+  ...
+)
 }
 \arguments{
 \item{object}{An object of class "\code{thetam}.  Usually the result of a call to \code{link{thetam}}.}

--- a/pkg/man/hybridModel.Rd
+++ b/pkg/man/hybridModel.Rd
@@ -4,12 +4,26 @@
 \alias{hybridModel}
 \title{Hybrid time series modeling}
 \usage{
-hybridModel(y, models = "aefnst", lambda = NULL, a.args = NULL,
-  e.args = NULL, n.args = NULL, s.args = NULL, t.args = NULL,
-  z.args = NULL, weights = c("equal", "insample.errors", "cv.errors"),
-  errorMethod = c("RMSE", "MAE", "MASE"), rolling = FALSE,
-  cvHorizon = frequency(y), windowSize = 84, horizonAverage = FALSE,
-  parallel = FALSE, num.cores = 2L, verbose = TRUE)
+hybridModel(
+  y,
+  models = "aefnst",
+  lambda = NULL,
+  a.args = NULL,
+  e.args = NULL,
+  n.args = NULL,
+  s.args = NULL,
+  t.args = NULL,
+  z.args = NULL,
+  weights = c("equal", "insample.errors", "cv.errors"),
+  errorMethod = c("RMSE", "MAE", "MASE"),
+  rolling = FALSE,
+  cvHorizon = frequency(y),
+  windowSize = 84,
+  horizonAverage = FALSE,
+  parallel = FALSE,
+  num.cores = 2L,
+  verbose = TRUE
+)
 }
 \arguments{
 \item{y}{A numeric vector or time series.}

--- a/pkg/man/plot.hybridModel.Rd
+++ b/pkg/man/plot.hybridModel.Rd
@@ -4,8 +4,7 @@
 \alias{plot.hybridModel}
 \title{Plot a hybridModel object}
 \usage{
-\method{plot}{hybridModel}(x, type = c("fit", "models"),
-  ggplot = FALSE, ...)
+\method{plot}{hybridModel}(x, type = c("fit", "models"), ggplot = FALSE, ...)
 }
 \arguments{
 \item{x}{an object of class hybridModel to plot.}

--- a/pkg/man/thiefModel.Rd
+++ b/pkg/man/thiefModel.Rd
@@ -4,8 +4,7 @@
 \alias{thiefModel}
 \title{Forecast ensemble using THieF}
 \usage{
-thiefModel(y, models = "aefnt", h = 2 * frequency(y),
-  verbose = FALSE)
+thiefModel(y, models = "aefnt", h = 2 * frequency(y), verbose = FALSE)
 }
 \arguments{
 \item{y}{the input time series}


### PR DESCRIPTION
For better consistency with the signature of `fabletools::accuracy()` and other generics, the `forecast::accuracy()` generic will be updated in the next release (https://github.com/robjhyndman/forecast/commit/6b9ab090cd01062460c285d17dd6bc6d6d310a48).

This PR updates accuracy methods to use this updated generic signature.