### PR TITLE
ARFIMA models.

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
    )
 Description: Convenient functions for ensemble forecasts in R combining
     approaches from the 'forecast' package. Forecasts generated from auto.arima(), ets(),
-    thetaf(), nnetar(), stlm(), tbats(), and snaive() can be combined with equal weights, weights
+    thetaf(), nnetar(), stlm(), tbats(), snaive() and arfima() can be combined with equal weights, weights
     based on in-sample errors (introduced by Bates & Granger (1969) <doi:10.1057/jors.1969.103>),
     or cross-validated weights. Cross validation for time series data with user-supplied models
     and forecasting functions is also supported to evaluate model accuracy.
@@ -22,7 +22,7 @@ Imports:
     ggplot2 (>= 2.2.0),
     purrr (>= 0.2.5),
     zoo (>= 1.7)
-Suggests:
+Suggests:    
     GMDH,
     knitr,
     rmarkdown,
@@ -33,7 +33,7 @@ License: GPL-3
 URL: https://gitlab.com/dashaub/forecastHybrid, https://github.com/ellisp/forecastHybrid
 BugReports: https://github.com/ellisp/forecastHybrid/issues
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 ByteCompile: true
 NeedsCompilation: no
 Encoding: UTF-8

--- a/pkg/R/forecast.hybridModel.R
+++ b/pkg/R/forecast.hybridModel.R
@@ -155,6 +155,10 @@ forecast.hybridModel <- function(object,
     forecasts$snaive <- snaive(object$x, h = h, level = level, ...)
     forecasts$pointForecasts[, "snaive"] <- forecasts$snaive$mean
   }
+  if("arfima" %in% includedModels){
+    forecasts$arfima <- forecast(object$arfima, h = h, level = level, ...)
+    forecasts$pointForecasts[, "arfima"] <- forecasts$arfima$mean
+  }
 
   # Apply the weights to the individual forecasts and create the final point forecast
   finalForecast <- rowSums(forecasts$pointForecast * weightsMatrix)

--- a/pkg/R/generics.R
+++ b/pkg/R/generics.R
@@ -80,10 +80,10 @@ residuals.hybridModel <- function(object,
 #'
 #' @author David Shaub
 #'
-accuracy.hybridModel <- function(object,
-                                 individual = FALSE,
-                                 ...,
-                                 f = NULL){
+accuracy.hybridModel <-  function(object,
+                               individual = FALSE,
+                               ...,
+                               f = NULL){
   if(!is.null(f)){
     warning("Using `f` as the argument for `accuracy()` is deprecated. Please use `object` instead.")
     object <- f
@@ -92,7 +92,7 @@ accuracy.hybridModel <- function(object,
   if(individual){
     results <- list()
     for(model in object$models){
-      results[[model]] <- forecast::accuracy(object[[model]])
+      results[[model]] <- forecast::accuracy(fitted(object[[model]]),object$x)
     }
     return(results)
   }

--- a/pkg/R/generics.R
+++ b/pkg/R/generics.R
@@ -86,8 +86,7 @@ accuracy.hybridModel <-  function(object,
                                f = NULL){
   if(!is.null(f)){
     warning("Using `f` as the argument for `accuracy()` is deprecated. Please use `object` instead.")
-    object <- f
-  }
+    object <- f}
   #chkDots(...)
   if(individual){
     results <- list()

--- a/pkg/R/generics.R
+++ b/pkg/R/generics.R
@@ -86,7 +86,8 @@ accuracy.hybridModel <-  function(object,
                                f = NULL){
   if(!is.null(f)){
     warning("Using `f` as the argument for `accuracy()` is deprecated. Please use `object` instead.")
-    object <- f}
+    object <- f
+    }
   #chkDots(...)
   if(individual){
     results <- list()

--- a/pkg/R/helper.R
+++ b/pkg/R/helper.R
@@ -72,7 +72,7 @@ tsSubsetWithIndices <- function(x, indices) {
 #' @seealso \code{\link{hybridModel}}
 getModel <- function(modelCharacter){
   models <- c("a" = auto.arima, "e" = ets, "f" = thetam, "n" = nnetar,
-              "s" = stlm, "t" = tbats, "z" = snaive)
+              "s" = stlm, "t" = tbats, "z" = snaive, "x"=arfima)
   return(models[[modelCharacter]])
 }
 
@@ -89,7 +89,7 @@ getModel <- function(modelCharacter){
 #' @seealso \code{\link{hybridModel}}
 getModelName <- function(modelCharacter){
   models <- c("a" = "auto.arima", "e" = "ets", "f" = "thetam", "n" = "nnetar",
-              "s" = "stlm", "t" = "tbats", "z" = "snaive")
+              "s" = "stlm", "t" = "tbats", "z" = "snaive", "x"="arfima")
   return(as.character(models[modelCharacter]))
 }
 
@@ -120,7 +120,7 @@ removeModels <- function(y, models){
     stop("Invalid models specified.")
   }
   # All characters must be valid
-  validModels <- c("a", "e", "f", "n", "s", "t", "z")
+  validModels <- c("a", "e", "f", "n", "s", "t", "z", "x")
   if(!all(expandedModels %in% validModels)){
     stop("Invalid models specified.")
   }

--- a/pkg/R/hybridModel.R
+++ b/pkg/R/hybridModel.R
@@ -22,11 +22,13 @@
 #' @param s.args an optional \code{list} of arguments to pass to \code{\link[forecast]{stlm}}. See details.
 #' @param t.args an optional \code{list} of arguments to pass to \code{\link[forecast]{tbats}}. See details.
 #' @param z.args an optional \code{list} of arguments to pass to \code{\link[forecast]{snaive}}. See details.
+#' @param x.args an optional \code{list} of arguments to pass to \code{\link[forecast]{arfima}}. See details.
+
 #' @param weights method for weighting the forecasts of the various contributing
 #' models.  Defaults to \code{equal}, which has shown to be robust and better
 #' in many cases than giving more weight to models with better in-sample performance. Cross validated errors--implemented with \code{link{cvts}}
 #' should produce the best forecast, but the model estimation is also the slowest. Note that extra arguments
-#' passed in \code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, and \code{t.args} are not used
+#' passed in \code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, \code{x.args} and \code{t.args} are not used
 #' during cross validation. See further explanation in \code{\link{cvts}}.
 #' Weights utilizing in-sample errors are also available but not recommended.
 #' @param errorMethod  method of measuring accuracy to use if weights are not
@@ -55,7 +57,7 @@
 #' @details The \code{hybridModel} function fits multiple individual model specifications to allow easy creation
 #' of ensemble forecasts. While default settings for the individual component models work quite well
 #' in most cases, fine control can be exerted by passing detailed arguments to the component models in the
-#' \code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, and \code{t.args} lists.
+#' \code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, \code{x.args}, and \code{t.args} lists.
 #' Note that if \code{xreg} is passed to the \code{a.args}, \code{n.args}, or \code{s.args} component models
 #' it must now be passed as a matrix. In "forecastHybrid" versions earlier than 4.0.15 it would
 #' instead be passed in as a dataframe, but for consistency with "forecast" v8.5 we now require
@@ -77,7 +79,7 @@
 #' @examples
 #' \dontrun{
 #'
-#' # Fit an auto.arima, ets, thetam, nnetar, stlm, and tbats model
+#' # Fit an auto.arima, ets, thetam, nnetar, stlm, arfima, and tbats model
 #' # on the time series with equal weights
 #' mod1 <- hybridModel(AirPassengers)
 #' plot(forecast(mod1))
@@ -106,6 +108,7 @@ hybridModel <- function(y, models = "aefnst",
                         s.args = NULL,
                         t.args = NULL,
                         z.args = NULL,
+                        x.args=NULL,
                         weights = c("equal", "insample.errors", "cv.errors"),
                         errorMethod = c("RMSE", "MAE", "MASE"),
                         rolling = FALSE,
@@ -119,7 +122,7 @@ hybridModel <- function(y, models = "aefnst",
   # Validate input
   ##############################################################################
   modelArguments = list("a" = a.args, "e" = e.args, "f" = NULL, "n" = n.args,
-                    "s" = s.args, "t" = t.args, "z" = z.args)
+                    "s" = s.args, "t" = t.args, "z" = z.args, "x"=x.args)
 
   # Validate and clean the input timeseries
   y <- prepareTimeseries(y = y)
@@ -142,7 +145,7 @@ hybridModel <- function(y, models = "aefnst",
   # Check the parallel arguments
   checkParallelArguments(parallel = parallel, num.cores = num.cores)
 
-  # Check a.args/t.args/e.args/n.args/s.args
+  # Check a.args/t.args/e.args/n.args/s.args/x.args
   checkModelArgs(modelArguments = modelArguments, models = expandedModels)
 
   if(weights == "cv.errors" && errorMethod == "MASE"){

--- a/pkg/R/hybridModel.R
+++ b/pkg/R/hybridModel.R
@@ -306,3 +306,4 @@ hybridModel <- function(y, models = "aefnst",
   modelResults$residuals <- resid
   return(modelResults)
 }
+

--- a/pkg/man/hybridModel.Rd
+++ b/pkg/man/hybridModel.Rd
@@ -50,12 +50,12 @@ Ignored if NULL. Otherwise, data transformed before model is estimated.}
 \item{z.args}{an optional \code{list} of arguments to pass to \code{\link[forecast]{snaive}}. See details.}
 
 \item{x.args}{an optional \code{list} of arguments to pass to \code{\link[forecast]{arfima}}. See details.}
-  
+
 \item{weights}{method for weighting the forecasts of the various contributing
 models.  Defaults to \code{equal}, which has shown to be robust and better
 in many cases than giving more weight to models with better in-sample performance. Cross validated errors--implemented with \code{link{cvts}}
 should produce the best forecast, but the model estimation is also the slowest. Note that extra arguments
-passed in \code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, and \code{t.args} are not used
+passed in \code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, \code{x.args} and \code{t.args} are not used
 during cross validation. See further explanation in \code{\link{cvts}}.
 Weights utilizing in-sample errors are also available but not recommended.}
 
@@ -118,7 +118,7 @@ a series well with a seasonal period longer than 24 and will ignore the seasonal
 \examples{
 \dontrun{
 
-# Fit an auto.arima, ets, thetam, nnetar, stlm, arfima and tbats model
+# Fit an auto.arima, ets, thetam, nnetar, stlm, arfima, and tbats model
 # on the time series with equal weights
 mod1 <- hybridModel(AirPassengers)
 plot(forecast(mod1))

--- a/pkg/man/hybridModel.Rd
+++ b/pkg/man/hybridModel.Rd
@@ -14,6 +14,7 @@ hybridModel(
   s.args = NULL,
   t.args = NULL,
   z.args = NULL,
+  x.args = NULL,
   weights = c("equal", "insample.errors", "cv.errors"),
   errorMethod = c("RMSE", "MAE", "MASE"),
   rolling = FALSE,
@@ -48,6 +49,8 @@ Ignored if NULL. Otherwise, data transformed before model is estimated.}
 
 \item{z.args}{an optional \code{list} of arguments to pass to \code{\link[forecast]{snaive}}. See details.}
 
+\item{x.args}{an optional \code{list} of arguments to pass to \code{\link[forecast]{arfima}}. See details.}
+  
 \item{weights}{method for weighting the forecasts of the various contributing
 models.  Defaults to \code{equal}, which has shown to be robust and better
 in many cases than giving more weight to models with better in-sample performance. Cross validated errors--implemented with \code{link{cvts}}
@@ -93,7 +96,7 @@ Create a hybrid time series model with two to five component models.
 The \code{hybridModel} function fits multiple individual model specifications to allow easy creation
 of ensemble forecasts. While default settings for the individual component models work quite well
 in most cases, fine control can be exerted by passing detailed arguments to the component models in the
-\code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, and \code{t.args} lists.
+\code{a.args}, \code{e.args}, \code{n.args}, \code{s.args}, \code{x.args}, and \code{t.args} lists.
 Note that if \code{xreg} is passed to the \code{a.args}, \code{n.args}, or \code{s.args} component models
 it must now be passed as a matrix. In "forecastHybrid" versions earlier than 4.0.15 it would
 instead be passed in as a dataframe, but for consistency with "forecast" v8.5 we now require
@@ -115,7 +118,7 @@ a series well with a seasonal period longer than 24 and will ignore the seasonal
 \examples{
 \dontrun{
 
-# Fit an auto.arima, ets, thetam, nnetar, stlm, and tbats model
+# Fit an auto.arima, ets, thetam, nnetar, stlm, arfima and tbats model
 # on the time series with equal weights
 mod1 <- hybridModel(AirPassengers)
 plot(forecast(mod1))


### PR DESCRIPTION
I just made a few changes to allow the use of arfima models ("x"). I think it could be useful to forecast times serie with long memory.  I am working on forecasting economic indicators in brazil and ARFIMA model is often outperforming ARIMA models on consumer and producer price index especially when frequency is equal to 36 or 52.  So from my professionnal point of view, it make sense to allow both ARFIMA and ARIMA models in the hybridModel function. 

Arfima function accept x.args but not xreg yet. 

